### PR TITLE
Add homepage News section showing latest 10 combined updates

### DIFF
--- a/_includes/home-news.html
+++ b/_includes/home-news.html
@@ -1,0 +1,101 @@
+<div class="home-news-section content">
+  <ul id="home-news-list"></ul>
+
+  <div class="has-text-centered mt-4">
+    <a class="button is-link is-light" href="{{ '/news/news' | relative_url }}">More News</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const monthMap = {
+    jan: 1,
+    feb: 2,
+    mar: 3,
+    apr: 4,
+    may: 5,
+    jun: 6,
+    jul: 7,
+    aug: 8,
+    sep: 9,
+    oct: 10,
+    nov: 11,
+    dec: 12
+  };
+
+  function parseDateValue(dateText) {
+    if (!dateText) {
+      return 0;
+    }
+
+    const yearMatch = dateText.match(/(\d{4})/);
+    const year = yearMatch ? parseInt(yearMatch[1], 10) : 0;
+
+    const monthMatch = dateText.toLowerCase().match(/(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/);
+    const month = monthMatch ? (monthMap[monthMatch[1]] || 0) : 0;
+
+    return year * 100 + month;
+  }
+
+  const allNews = [
+    {% for paper in site.data.news.papers %}
+      {
+        date: {{ paper.date | jsonify }},
+        description: {{ paper.description | jsonify }},
+        authors: {{ paper.authors | default: '' | jsonify }}
+      },
+    {% endfor %}
+    {% for award in site.data.news.awards %}
+      {
+        date: {{ award.date | jsonify }},
+        description: {{ award.description | jsonify }},
+        link: {{ award.link | default: '' | jsonify }}
+      },
+    {% endfor %}
+    {% for project in site.data.news.projects %}
+      {
+        date: {{ project.date | jsonify }},
+        description: {{ project.description | jsonify }}
+      },
+    {% endfor %}
+    {% for person in site.data.news.people %}
+      {
+        date: {{ person.date | jsonify }},
+        description: {{ person.description | jsonify }}
+      },
+    {% endfor %}
+  ];
+
+  allNews.sort((a, b) => parseDateValue(b.date) - parseDateValue(a.date));
+
+  const latestNews = allNews.slice(0, 10);
+  const listEl = document.getElementById('home-news-list');
+
+  latestNews.forEach((item) => {
+    const li = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = item.date || '';
+
+    li.appendChild(strong);
+    li.appendChild(document.createTextNode(' - ' + (item.description || '')));
+
+    if (item.authors) {
+      const authorStrong = document.createElement('strong');
+      authorStrong.style.color = '#1f2a44';
+      authorStrong.textContent = ' (' + item.authors + ')';
+      li.appendChild(authorStrong);
+    }
+
+    if (item.link) {
+      const link = document.createElement('a');
+      link.href = item.link;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = ' [Read more]';
+      li.appendChild(link);
+    }
+
+    listEl.appendChild(li);
+  });
+})();
+</script>

--- a/index.md
+++ b/index.md
@@ -25,6 +25,10 @@ Our autonomous multi-robot systems **perceive**, **adapt**, and **collaborate** 
 
 {% include recent-papers.html %}
 
+## News
+
+{% include home-news.html %}
+
 ---
 
 


### PR DESCRIPTION
### Motivation
- Provide a single, up-to-date News feed on the homepage that surfaces the latest items regardless of their category so new items added to the News data automatically appear on the main page. 
- Limit visible items to a manageable number with a clear path to the full News page via a `More News` button.

### Description
- Added `_includes/home-news.html`, which builds a unified `allNews` array by iterating `site.data.news.papers`, `awards`, `projects`, and `people`, then sorts items by parsed month/year and limits output to the latest 10 items.
- The include renders date, description, optional authors and links, and a `More News` button linking to `/news/news`.
- Inserted `## News` and `{% include home-news.html %}` into `index.md` directly below `Recent Activities` so the homepage shows the new feed.
- Commit recorded the two-file change (`index.md` and `_includes/home-news.html`).

### Testing
- Verified working tree and file contents with `git status` and `nl -ba` for the new include and `index.md`, which succeeded. 
- Attempted `bundle exec jekyll build`, which failed because `jekyll` is not available in the local environment (`bundler: command not found: jekyll`).
- Attempted `bundle install`, which failed due to network/gem fetch errors (rubygems returned HTTP 403), so dependency installation could not be completed.
- Ran a Playwright page load script to capture the homepage, which failed because no local Jekyll server was running (`net::ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c65607b3883258ff0995d0b40351d)