### PR TITLE
Promote faculty status, add homepage news feed, and update publications

### DIFF
--- a/_data/current_members.yml
+++ b/_data/current_members.yml
@@ -4,7 +4,7 @@
       alt: Younggun Cho
       description: |-
         **Younggun Cho**  
-        Assistant Professor
+        Associate Professor
       page_link: /people/Faculty/Younggun-Cho 
 
 - title: PhD Student

--- a/_data/international_publications.yml
+++ b/_data/international_publications.yml
@@ -10,6 +10,12 @@
       conf: "IEEE International Conference on Robotics and Automation (ICRA)"
       conf_link: "https://2026.ieee-icra.org/"
 
+    - alt: "MSG-Loc: Multi-Label Likelihood-based Semantic Graph Matching for Object-Level Global Localization"
+      authors: "Gihyeon Lee, Jungwoo Lee, Juwon Kim, Young-Sik Shin, and Younggun Cho"
+      conf: "IEEE Robotics and Automation Letters (RA-L)"
+      conf_link: "https://www.ieee-ras.org/publications/ra-l"
+      arxiv: "https://doi.org/10.48550/arXiv.2512.03522"
+
 
 - title: "2025"
   images:
@@ -17,12 +23,6 @@
       authors: "Miryeong Park, Dongjin Cho, Sanghyun Kim, and Younggun Cho"
       conf: "International Conference on Space Robotics (iSpaRo) "
       conf_link: "https://www.isparo.space/"
-
-    - alt: "MSG-Loc: Multi-Label Likelihood-based Semantic Graph Matching for Object-Level Global Localization"
-      authors: "Gihyeon Lee, Jungwoo Lee, Juwon Kim, Young-Sik Shin, and Younggun Cho"
-      conf: "IEEE Robotics and Automation Letters (RA-L)"
-      conf_link: "https://www.ieee-ras.org/publications/ra-l"
-      arxiv: "https://doi.org/10.48550/arXiv.2512.03522"
 
     - alt: "Freeze-Frame with StaticNeRF Uncertainty-Guided NeRF Map Reconstruction in Dynamic Scenes"
       authors: "Juhui Lee, Geonmo Yang, Seungjun Ma, and Younggun Cho"

--- a/_includes/home-news.html
+++ b/_includes/home-news.html
@@ -1,0 +1,101 @@
+<div class="home-news-section content">
+  <ul id="home-news-list"></ul>
+
+  <div class="has-text-centered mt-4">
+    <a class="button is-link is-light" href="{{ '/news/news' | relative_url }}">More News</a>
+  </div>
+</div>
+
+<script>
+(function () {
+  const monthMap = {
+    jan: 1,
+    feb: 2,
+    mar: 3,
+    apr: 4,
+    may: 5,
+    jun: 6,
+    jul: 7,
+    aug: 8,
+    sep: 9,
+    oct: 10,
+    nov: 11,
+    dec: 12
+  };
+
+  function parseDateValue(dateText) {
+    if (!dateText) {
+      return 0;
+    }
+
+    const yearMatch = dateText.match(/(\d{4})/);
+    const year = yearMatch ? parseInt(yearMatch[1], 10) : 0;
+
+    const monthMatch = dateText.toLowerCase().match(/(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/);
+    const month = monthMatch ? (monthMap[monthMatch[1]] || 0) : 0;
+
+    return year * 100 + month;
+  }
+
+  const allNews = [
+    {% for paper in site.data.news.papers %}
+      {
+        date: {{ paper.date | jsonify }},
+        description: {{ paper.description | jsonify }},
+        authors: {{ paper.authors | default: '' | jsonify }}
+      },
+    {% endfor %}
+    {% for award in site.data.news.awards %}
+      {
+        date: {{ award.date | jsonify }},
+        description: {{ award.description | jsonify }},
+        link: {{ award.link | default: '' | jsonify }}
+      },
+    {% endfor %}
+    {% for project in site.data.news.projects %}
+      {
+        date: {{ project.date | jsonify }},
+        description: {{ project.description | jsonify }}
+      },
+    {% endfor %}
+    {% for person in site.data.news.people %}
+      {
+        date: {{ person.date | jsonify }},
+        description: {{ person.description | jsonify }}
+      },
+    {% endfor %}
+  ];
+
+  allNews.sort((a, b) => parseDateValue(b.date) - parseDateValue(a.date));
+
+  const latestNews = allNews.slice(0, 10);
+  const listEl = document.getElementById('home-news-list');
+
+  latestNews.forEach((item) => {
+    const li = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = item.date || '';
+
+    li.appendChild(strong);
+    li.appendChild(document.createTextNode(' - ' + (item.description || '')));
+
+    if (item.authors) {
+      const authorStrong = document.createElement('strong');
+      authorStrong.style.color = '#1f2a44';
+      authorStrong.textContent = ' (' + item.authors + ')';
+      li.appendChild(authorStrong);
+    }
+
+    if (item.link) {
+      const link = document.createElement('a');
+      link.href = item.link;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = ' [Read more]';
+      li.appendChild(link);
+    }
+
+    listEl.appendChild(li);
+  });
+})();
+</script>

--- a/index.md
+++ b/index.md
@@ -25,6 +25,10 @@ Our autonomous multi-robot systems **perceive**, **adapt**, and **collaborate** 
 
 {% include recent-papers.html %}
 
+## News
+
+{% include home-news.html %}
+
 ---
 
 

--- a/people/Faculty/Younggun-Cho.md
+++ b/people/Faculty/Younggun-Cho.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Younggun Cho
-subtitle: Assistant Professor
+subtitle: Associate Professor
 permalink: /people/Faculty/Younggun-Cho
 ---
 
@@ -52,11 +52,11 @@ permalink: /people/Faculty/Younggun-Cho
   <div class="media-content">
     <div class="content">
       <p>
-        I am an assistant professor of the Department of Electrical Engineering at Inha University.  
+        I am an associate professor of the Department of Electrical and Electronic Engineering at Inha University.  
         <br><br>
         Before joining Inha University, I was an assistant professor in the Department of Robotics Engineering at Yeungnam. Also, I was a postdoctoral researcher at KAIST. My research interest is long-term autonomy and robust sensing, including SLAM (Simultaneous Localization and Mapping) for field robots, vision-based perception, and physical-based learning.  
         <br><br>
-        I received the Ph. D. degree in the Department of Civil and Environmental Engineering with Robotics program at KAIST Daejeon, South Korea, advised by Prof. Ayoung Kim. Also, I received M.S. degree in the Department of Electrical Engineering at KAIST, advised by Prof. Myungjin Chung. Before that, I received the B.E. degree in the Department of Electrical in Inha University, Incheon, South Korea.
+        I received the Ph. D. degree in the Department of Civil and Environmental Engineering with Robotics program at KAIST Daejeon, South Korea, advised by Prof. Ayoung Kim. Also, I received M.S. degree in the Department of Electrical and Electronic Engineering at KAIST, advised by Prof. Myungjin Chung. Before that, I received the B.E. degree in the Department of Electrical in Inha University, Incheon, South Korea.
         <br><br>
       </p>
       <p>


### PR DESCRIPTION
### Motivation
- Reflect a recent faculty promotion by changing Younggun Cho's role from `Assistant Professor` to `Associate Professor` across site data and profile pages.
- Surface recent lab news on the homepage by adding a lightweight client-side aggregator for items stored in the `data/news` collections.
- Correct and reorganize a publication entry by moving/adding the `MSG-Loc` record into the `2026` publications list.

### Description
- Updated `/_data/current_members.yml` to change Younggun Cho's description to `Associate Professor`.
- Updated `people/Faculty/Younggun-Cho.md` to revise the `subtitle`, department phrasing, and related biography text to match the new title.
- Added a new include `/_includes/home-news.html` which implements a small JavaScript aggregator that merges `data/news` collections, sorts by date, and renders the latest entries into the homepage.
- Modified `index.md` to include the new news include and updated `/_data/international_publications.yml` to place the `MSG-Loc` publication under `2026`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c65607b3883258ff0995d0b40351d)