### PR TITLE
Remove duplicated News section from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -29,14 +29,6 @@ Our autonomous multi-robot systems **perceive**, **adapt**, and **collaborate** 
 
 {% include home-news.html %}
 
----
-
-## News
-
-{% include home-news.html %}
-
----
-
 
 
 
@@ -73,4 +65,3 @@ Our autonomous multi-robot systems **perceive**, **adapt**, and **collaborate** 
 * [Apr. 2022] SPARO Lab started the joint project (Industry-academy collaboration, Partner: Neubility)
 * [Apr. 2022] One paper is accepted to RA-L (Vivid++)
 * [Mar. 2022] Geonmo, Jooyong, and Juhui joined SPARO Lab! Welcome! -->
-


### PR DESCRIPTION
### Motivation
- Fix a UI bug where the homepage rendered the `News` list twice due to a duplicated include block in the homepage source.

### Description
- Remove the second `## News` heading and duplicate `{% include home-news.html %}` block from `index.md` so the news list is included only once.

### Testing
- Ran a diff inspection with `git diff -- index.md` to confirm the duplicate block was removed and it succeeded.
- Verified presence of a single `## News` and one `{% include home-news.html %}` via `rg -n '^## News$|home-news.html' index.md` and it succeeded.
- Attempted `bundle exec jekyll build` to validate site build but it failed due to the environment missing the `jekyll` executable.
- Attempted a Playwright screenshot of `http://127.0.0.1:4000` to visually confirm the homepage but it failed with `ERR_EMPTY_RESPONSE` because the local server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c79faa50832597f689302850ab12)