### PR TITLE
Add 'Prospective Students' page and 'Join Us' navigation entry

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -33,3 +33,6 @@
 
 - name: Album
   link: /album/album
+- name: Join Us
+  link: /prospective-students
+

--- a/prospective-students.md
+++ b/prospective-students.md
@@ -1,0 +1,280 @@
+---
+layout: page
+title: Prospective Students
+show_sidebar: false
+hide_footer: false
+hero_height: is-small
+permalink: /prospective-students/
+---
+
+<style>
+  .prospective-page {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  .prospective-page section {
+    margin-top: 2rem;
+  }
+
+  .prospective-page h2,
+  .prospective-page h3 {
+    margin-bottom: 0.75rem;
+  }
+
+  .research-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  .research-card {
+    border: 1px solid #dbdbdb;
+    border-radius: 6px;
+    padding: 1rem;
+    background: #fff;
+    height: 100%;
+  }
+
+  .research-card h3 {
+    font-size: 1.05rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .apply-button-wrap {
+    margin-top: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .lang-divider {
+    margin-top: 2.5rem;
+    margin-bottom: 1.5rem;
+  }
+</style>
+
+<div class="content prospective-page">
+  <section aria-labelledby="join-sparo-lab">
+    <h2 id="join-sparo-lab">Join SPARO Lab</h2>
+    <p>
+      SPARO Lab at Inha University focuses on building spatial intelligence for real-world robotics. Our goal is to enable robots to understand, navigate, and collaborate in complex and dynamic environments beyond controlled laboratory settings.
+    </p>
+    <p>
+      We are particularly interested in robust and scalable robot autonomy, where perception, mapping, and decision-making are tightly integrated under real-world constraints such as noise, uncertainty, and limited communication.
+    </p>
+    <p>
+      Our research spans from fundamental algorithms to real-world deployment, with a strong emphasis on field validation and system-level integration.
+    </p>
+  </section>
+
+  <section aria-labelledby="research-areas">
+    <h2 id="research-areas">Research Areas</h2>
+    <div class="research-grid">
+      <article class="research-card">
+        <h3>Spatial AI and SLAM</h3>
+        <ul>
+          <li>Multi-session and multi-robot SLAM</li>
+          <li>Topometric and semantic mapping</li>
+          <li>Communication-efficient map representation</li>
+          <li>Robust localization in degraded environments</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>Robust Robot Perception</h3>
+        <ul>
+          <li>Multi-modal sensing including LiDAR, Radar, RGB, and Thermal</li>
+          <li>All-weather perception</li>
+          <li>Uncertainty-aware perception</li>
+          <li>Underwater and maritime vision</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>Multi-Robot Systems</h3>
+        <ul>
+          <li>Collaborative mapping and localization</li>
+          <li>Distributed spatial intelligence</li>
+          <li>Communication-aware coordination</li>
+          <li>Heterogeneous robot collaboration</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>Physical AI and Robot Learning</h3>
+        <ul>
+          <li>Learning-based navigation</li>
+          <li>Sim-to-real transfer</li>
+          <li>Traversability estimation</li>
+          <li>Perception-action coupling</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>Field Robotics</h3>
+        <ul>
+          <li>Maritime robotics</li>
+          <li>Autonomous delivery robots</li>
+          <li>Service robots in real environments</li>
+          <li>Large-scale deployment scenarios</li>
+        </ul>
+      </article>
+    </div>
+  </section>
+
+  <section aria-labelledby="research-environment">
+    <h2 id="research-environment">Research Environment</h2>
+    <p>
+      SPARO Lab provides a strong experimental and collaborative environment, including an indoor home-like testbed with motion capture system, simulation environments such as Isaac Sim and Gazebo, and various robotic platforms including mobile robots, legged robots, and service robots.
+    </p>
+    <p>
+      Students are encouraged to work on both theoretical research and real-world systems.
+    </p>
+  </section>
+
+  <section aria-labelledby="what-we-expect">
+    <h2 id="what-we-expect">What We Expect</h2>
+    <ul>
+      <li>Strong interest in robotics and AI</li>
+      <li>Motivation to solve challenging real-world problems</li>
+      <li>Willingness to work on both theory and systems</li>
+      <li>Experience with, or willingness to learn, Python or C++</li>
+      <li>Experience with, or willingness to learn, ROS or ROS2</li>
+      <li>Basic background in machine learning, deep learning, or robotics</li>
+    </ul>
+  </section>
+
+  <section aria-labelledby="what-you-will-gain">
+    <h2 id="what-you-will-gain">What You Will Gain</h2>
+    <ul>
+      <li>Hands-on experience with real robotic systems</li>
+      <li>Opportunities to publish in top-tier venues such as ICRA, IROS, and RA-L</li>
+      <li>Experience with large-scale research projects</li>
+      <li>Collaboration opportunities with industry and international research groups</li>
+    </ul>
+  </section>
+
+  <section aria-labelledby="open-positions">
+    <h2 id="open-positions">Open Positions</h2>
+    <ul>
+      <li>M.S. students</li>
+      <li>Ph.D. students</li>
+      <li>Integrated M.S./Ph.D. students</li>
+      <li>Undergraduate interns</li>
+    </ul>
+  </section>
+
+  <section aria-labelledby="how-to-apply-en">
+    <h2 id="how-to-apply-en">How to Apply</h2>
+    <p>Please apply using the Google Form below.</p>
+    <div class="apply-button-wrap">
+      <a class="button is-link" href="https://forms.gle/ZVjmPErb3VBMSXj89" target="_blank" rel="noopener noreferrer">Apply via Google Form</a>
+    </div>
+    <p>If you have questions, please contact the lab by email.</p>
+    <p><strong>Email:</strong> yg.cho at inha.ac.kr</p>
+  </section>
+
+  <hr class="lang-divider" />
+
+  <section aria-labelledby="korean-recruitment">
+    <h2 id="korean-recruitment">학생 모집 안내</h2>
+
+    <h3>연구실 소개</h3>
+    <p>
+      SPARO Lab은 인하대학교 로봇 연구실로, 실세계 환경에서 동작하는 공간지능 Spatial Intelligence을 연구합니다.
+    </p>
+    <p>
+      단순한 실험실 환경이 아니라, 다양한 센서 노이즈와 환경 변화, 제한된 통신 조건이 존재하는 상황에서도 로봇이 스스로 인지하고, 이동하고, 협력할 수 있는 기술을 개발하는 것을 목표로 합니다.
+    </p>
+    <p>
+      본 연구실은 알고리즘 수준의 연구뿐만 아니라 실제 로봇 시스템 구현과 현장 검증까지 포함하는 시스템 중심 연구를 지향합니다.
+    </p>
+
+    <h3>주요 연구 분야</h3>
+    <div class="research-grid">
+      <article class="research-card">
+        <h3>공간지능 및 SLAM</h3>
+        <ul>
+          <li>멀티 세션 및 멀티 로봇 SLAM</li>
+          <li>토포메트릭 및 시맨틱 맵</li>
+          <li>통신 효율 기반 맵 표현</li>
+          <li>열악 환경에서의 강건한 위치추정</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>강건한 로봇 인지</h3>
+        <ul>
+          <li>멀티모달 센싱 LiDAR Radar RGB Thermal</li>
+          <li>악천후 및 저가시 환경 인지</li>
+          <li>불확실성 기반 인지</li>
+          <li>수중 및 해양 환경 비전</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>멀티 로봇 시스템</h3>
+        <ul>
+          <li>협업 맵핑 및 위치추정</li>
+          <li>분산형 공간지능</li>
+          <li>통신 제약 기반 협력</li>
+          <li>이기종 로봇 협업</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>Physical AI 및 로봇 학습</h3>
+        <ul>
+          <li>학습 기반 네비게이션</li>
+          <li>Sim-to-Real 전이</li>
+          <li>주행 가능성 추정</li>
+          <li>인지 행동 통합 학습</li>
+        </ul>
+      </article>
+      <article class="research-card">
+        <h3>필드 로보틱스</h3>
+        <ul>
+          <li>해양 로봇</li>
+          <li>자율 배송 로봇</li>
+          <li>서비스 로봇</li>
+          <li>대규모 실환경 로봇 시스템</li>
+        </ul>
+      </article>
+    </div>
+
+    <h3>연구 환경</h3>
+    <p>
+      SPARO Lab은 모션캡처 기반 실내 테스트베드, Isaac Sim 및 Gazebo 등의 시뮬레이션 환경, 그리고 다양한 로봇 플랫폼을 바탕으로 연구를 수행합니다.
+    </p>
+    <p>
+      학생들은 이론과 실제 시스템을 함께 다루는 연구를 수행하게 됩니다.
+    </p>
+
+    <h3>지원 자격</h3>
+    <ul>
+      <li>로봇 및 인공지능에 관심 있는 학생</li>
+      <li>실제 문제 해결에 흥미가 있는 학생</li>
+      <li>이론과 시스템을 함께 다루고 싶은 학생</li>
+      <li>Python 또는 C++ 활용 가능자 또는 학습 의지가 있는 학생</li>
+      <li>ROS 또는 ROS2 경험자 또는 학습 의지가 있는 학생</li>
+      <li>머신러닝 딥러닝 로봇공학 기초 보유자 우대</li>
+    </ul>
+
+    <h3>학생이 얻게 될 경험</h3>
+    <ul>
+      <li>실제 로봇 시스템 개발 경험</li>
+      <li>ICRA IROS RA-L 등 국제 학술대회 및 저널 논문 연구 경험</li>
+      <li>대형 연구 프로젝트 참여 경험</li>
+      <li>산업체 및 해외 연구기관과의 협업 기회</li>
+    </ul>
+
+    <h3>모집 대상</h3>
+    <ul>
+      <li>석사과정</li>
+      <li>박사과정</li>
+      <li>석박통합과정</li>
+      <li>학부 인턴</li>
+    </ul>
+
+    <h3>지원 방법</h3>
+    <p>아래 구글 폼을 통해 지원해 주세요.</p>
+    <div class="apply-button-wrap">
+      <a class="button is-link" href="https://forms.gle/ZVjmPErb3VBMSXj89" target="_blank" rel="noopener noreferrer">구글 폼으로 지원하기</a>
+    </div>
+    <p>문의 사항은 이메일로 연락 바랍니다.</p>
+    <p><strong>이메일:</strong> yg.cho at inha.ac.kr</p>
+  </section>
+</div>


### PR DESCRIPTION
### Motivation
- Provide a dedicated bilingual recruitment page to inform prospective students about the lab and application process.
- Surface the recruitment page in the site navigation so visitors can easily find application information.
- Consolidate research areas, expectations, benefits, open positions, and contact/apply links in one page.

### Description
- Add `prospective-students.md` containing front matter, styles, and full English and Korean recruitment content including research areas, expectations, benefits, open positions, and an application link to the Google Form.
- Update `_data/navigation.yml` to add a new "Join Us" navigation item linking to `/prospective-students/`.
- Include structured HTML/CSS (grid and card styles) and an apply button to ensure the page matches site layout and is responsive.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d8f8ce848325b7eaed6eff7088a3)